### PR TITLE
Hide "Configure" action

### DIFF
--- a/MageFix/Customer/view/adminhtml/templates/tab/cart.phtml
+++ b/MageFix/Customer/view/adminhtml/templates/tab/cart.phtml
@@ -13,6 +13,17 @@
 <?php
     $listType = $block->getJsObjectName();
 ?>
+
+<style>
+    .col-action > a:first-of-type {
+        display: none;
+    }
+
+    .col-action > a:first-of-type + br {
+        display: none;
+    }
+</style>
+
 <script type="text/javascript">
 <?php echo $block->getJsObjectName() ?>cartControl = {
     reload: function (params) {


### PR DESCRIPTION
Clicking "Configure" results in a JS error, so hide it for now, since it's inherited from Magento's code.