### PR TITLE
Updated the _prepareCollection() method

### DIFF
--- a/MageFix/Customer/Block/Adminhtml/Edit/Tab/Cart.php
+++ b/MageFix/Customer/Block/Adminhtml/Edit/Tab/Cart.php
@@ -16,5 +16,29 @@ class Cart extends \Magento\Customer\Block\Adminhtml\Edit\Tab\Cart
         parent::_construct();
         $this->setTemplate('MageFix_Customer::tab/cart.phtml');
     }
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected function _prepareCollection()
+    {
+        $quote = $this->getQuote();
+
+        if ($quote) {
+            $collection = $quote->getItemsCollection(false);
+        } else {
+            $collection = $this->_dataCollectionFactory->create();
+        }
+
+        $collection->addFieldToFilter('parent_item_id', ['null' => true]);
+
+        $this->setCollection($collection);
+
+        if ($collection->isLoaded()) {
+            return $this;
+        } else {
+            return parent::_prepareCollection();
+        }
+    }
 
 }

--- a/MageFix/Customer/view/adminhtml/templates/tab/cart.phtml
+++ b/MageFix/Customer/view/adminhtml/templates/tab/cart.phtml
@@ -19,6 +19,10 @@
         display: none;
     }
 
+    .col-action > a:last-of-type {
+        display: block;
+    }
+
     .col-action > a:first-of-type + br {
         display: none;
     }


### PR DESCRIPTION
Fixes a fatal error that occurs when products have options in the cart. The admin page tries to load the item collection twice but the second time has fake product ID's from the product options that throws a fatal error in the magento/module-quote/Model/ResourceModel/Quote/Item/Collection.php::removeItemsWithAbsentProducts() method when it tries to remove them since it cannot find the quote item by the fake product ID key. This skips that step if the collection has already been loaded previously so we can just display the already loaded items on the grid.